### PR TITLE
Use the debian 12-based distroless image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN go mod download
 COPY *.go ./
 RUN go build -o webpush-fcm-relay
 
-FROM gcr.io/distroless/base
+FROM gcr.io/distroless/base-debian12
 COPY --from=build-env /go/src/webpush-fcm-relay/webpush-fcm-relay /
 
 ARG GIT_REPOSITORY_URL


### PR DESCRIPTION
Otherwise the container fails with

```
/webpush-fcm-relay: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by /webpush-fcm-relay)
```