### PR TITLE
Support standard webpush

### DIFF
--- a/webpush-fcm-relay.go
+++ b/webpush-fcm-relay.go
@@ -147,6 +147,8 @@ func handler(writer http.ResponseWriter, request *http.Request) {
 			requestLog.Error(fmt.Sprintf("Error retrieving salt: %s", err))
 			return
 		}
+	case "aes128gcm":
+		message.Data["rfc"] = "1"
 	default:
 		http.Error(writer, "Unsupported content encoding", http.StatusUnsupportedMediaType)
 		requestLog.Error(fmt.Sprintf("Unsupported content encoding: %s", request.Header.Get("Content-Encoding")))


### PR DESCRIPTION
Mastodon now support standard webpush: https://github.com/mastodon/mastodon/pull/33528, it will be in mastodon 4.4.0. If we want to migrate clients using FCM we need to support the standard push here too

The content in the `p` field is enough to decrypt the push notification, `rfc` is added to know it comes from a standard push notification. Another solution is to simply not set `k` and `s`, so if they aren't there, we know it is a standard push. But I think it is better to add a field for that